### PR TITLE
Update PDF form filler to find 'primary' setting

### DIFF
--- a/app/pdfs/donation_application_pdf.rb
+++ b/app/pdfs/donation_application_pdf.rb
@@ -4,8 +4,10 @@ class DonationApplicationPdf < FillablePdfForm
     @user = args[:user]
     @listing = args[:listing]
     @user_questionnaire = Questionnaire.find_by(name: @user.account_type)
-    @address = get_sanitized_attributes(@user.addresses.first, Address.new)
-    @contact = get_sanitized_attributes(@user.contact_infos.find_by(primary: true), ContactInfo.new)
+    address = @user.addresses.find_by(primary: true) || @user.addresses.first
+    contact = @user.contact_infos.find_by(primary: true) || @user.contact_infos.first
+    @address = get_sanitized_attributes(address, Address.new)
+    @contact = get_sanitized_attributes(contact, ContactInfo.new)
     @contact_name = "#{@contact[:first_name]} #{@contact[:last_name]}".titleize
     super()
   end


### PR DESCRIPTION
PDF form filler will first look for primary address and contact_info, then fall back to first record in collection, then fall back to creating a new object
